### PR TITLE
Lock notes (except Orchard) in wallet_tx_builder

### DIFF
--- a/src/wallet/asyncrpcoperation_common.cpp
+++ b/src/wallet/asyncrpcoperation_common.cpp
@@ -7,6 +7,39 @@
 
 extern UniValue signrawtransaction(const UniValue& params, bool fHelp);
 
+UniValue SendEffectedTransaction(
+        const CTransaction& tx,
+        const TransactionEffects& effects,
+        std::optional<std::reference_wrapper<CReserveKey>> reservekey,
+        bool testmode)
+{
+    UniValue o(UniValue::VOBJ);
+    // Send the transaction
+    if (!testmode) {
+        CWalletTx wtx(pwalletMain, tx);
+        // save the mapping from (receiver, txid) to UA
+        if (!pwalletMain->SaveRecipientMappings(tx.GetHash(), effects.GetPayments().GetResolvedPayments())) {
+            effects.UnlockSpendable();
+            // More details in debug log
+            throw JSONRPCError(RPC_WALLET_ERROR, "SendTransaction: SaveRecipientMappings failed");
+        }
+        CValidationState state;
+        if (!pwalletMain->CommitTransaction(wtx, reservekey, state)) {
+            effects.UnlockSpendable();
+            std::string strError = strprintf("SendTransaction: Transaction commit failed:: %s", state.GetRejectReason());
+            throw JSONRPCError(RPC_WALLET_ERROR, strError);
+        }
+        o.pushKV("txid", tx.GetHash().ToString());
+    } else {
+        // Test mode does not send the transaction to the network nor save the recipient mappings.
+        o.pushKV("test", 1);
+        o.pushKV("txid", tx.GetHash().ToString());
+        o.pushKV("hex", EncodeHexTx(tx));
+    }
+    effects.UnlockSpendable();
+    return o;
+}
+
 std::pair<CTransaction, UniValue> SignSendRawTransaction(UniValue obj, std::optional<std::reference_wrapper<CReserveKey>> reservekey, bool testmode) {
     // Sign the raw transaction
     UniValue rawtxnValue = find_value(obj, "rawtxn");

--- a/src/wallet/asyncrpcoperation_common.h
+++ b/src/wallet/asyncrpcoperation_common.h
@@ -55,6 +55,11 @@ UniValue SendTransaction(
     return o;
 }
 
+UniValue SendEffectedTransaction(
+        const CTransaction& tx,
+        const TransactionEffects& effects,
+        std::optional<std::reference_wrapper<CReserveKey>> reservekey,
+        bool testmode);
 
 /**
  * Sign and send a raw transaction.

--- a/src/wallet/asyncrpcoperation_sendmany.cpp
+++ b/src/wallet/asyncrpcoperation_sendmany.cpp
@@ -185,7 +185,7 @@ uint256 AsyncRPCOperation_sendmany::main_impl() {
                     strategy_);
             auto tx = buildResult.GetTxOrThrow();
 
-            UniValue sendResult = SendTransaction(tx, payments.GetResolvedPayments(), std::nullopt, testmode);
+            UniValue sendResult = SendEffectedTransaction(tx, effects, std::nullopt, testmode);
             set_result(sendResult);
 
             txid = tx.GetHash();

--- a/src/wallet/wallet_tx_builder.cpp
+++ b/src/wallet/wallet_tx_builder.cpp
@@ -182,16 +182,20 @@ PrepareTransactionResult WalletTxBuilder::PrepareTransaction(
 
     auto ovks = SelectOVKs(selector, spendable);
 
-    return TransactionEffects(
-            sendFromAccount,
-            anchorConfirmations,
-            spendable,
-            resolvedPayments,
-            changeAddr,
-            fee,
-            ovks.first,
-            ovks.second,
-            anchorHeight);
+    auto effects = TransactionEffects(
+        sendFromAccount,
+        anchorConfirmations,
+        spendable,
+        resolvedPayments,
+        changeAddr,
+        fee,
+        ovks.first,
+        ovks.second,
+        anchorHeight);
+
+    effects.LockSpendable();
+
+    return effects;
 }
 
 Payments InputSelection::GetPayments() const {
@@ -571,6 +575,7 @@ TransactionBuilderResult TransactionEffects::ApproveAndBuild(
 {
     auto requiredPrivacy = this->GetRequiredPrivacyPolicy();
     if (!strategy.IsCompatibleWith(requiredPrivacy)) {
+        UnlockSpendable();
         return TransactionBuilderResult(strprintf(
             "The specified privacy policy, %s, does not permit the creation of "
             "the requested transaction. Select %s or weaker to allow this transaction "
@@ -628,6 +633,7 @@ TransactionBuilderResult TransactionEffects::ApproveAndBuild(
     {
         LOCK(wallet.cs_wallet);
         if (!wallet.GetSaplingNoteWitnesses(saplingOutPoints, anchorConfirmations, witnesses, anchor)) {
+            UnlockSpendable();
             // This error should not appear once we're nAnchorConfirmations blocks past
             // Sapling activation.
             return TransactionBuilderResult("Insufficient Sapling witnesses.");
@@ -644,6 +650,7 @@ TransactionBuilderResult TransactionEffects::ApproveAndBuild(
             std::move(spendInfo.first),
             std::move(spendInfo.second)))
         {
+            UnlockSpendable();
             return TransactionBuilderResult(
                 strprintf("Failed to add Orchard note to transaction (check %s for details)", GetDebugLogPath())
             );
@@ -653,6 +660,7 @@ TransactionBuilderResult TransactionEffects::ApproveAndBuild(
     // Add Sapling spends
     for (size_t i = 0; i < saplingNotes.size(); i++) {
         if (!witnesses[i]) {
+            UnlockSpendable();
             return TransactionBuilderResult(strprintf(
                 "Missing witness for Sapling note at outpoint %s",
                 spendable.saplingNoteEntries[i].op.ToString()
@@ -715,6 +723,7 @@ TransactionBuilderResult TransactionEffects::ApproveAndBuild(
         // inputAnchor is not needed by builder.AddSproutInput as it is for Sapling.
         uint256 inputAnchor;
         if (!wallet.GetSproutNoteWitnesses(vOutPoints, anchorConfirmations, vSproutWitnesses, inputAnchor)) {
+            UnlockSpendable();
             // This error should not appear once we're nAnchorConfirmations blocks past
             // Sprout activation.
             return TransactionBuilderResult("Insufficient Sprout witnesses.");
@@ -747,5 +756,41 @@ TransactionBuilderResult TransactionEffects::ApproveAndBuild(
     }
 
     // Build the transaction
-    return builder.Build();
+    auto result = builder.Build();
+    if (result.IsError()) {
+        UnlockSpendable();
+    }
+    return result;
+}
+
+// TODO: Lock Orchard notes
+void TransactionEffects::LockSpendable() const
+{
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+    for (auto utxo : spendable.utxos) {
+        COutPoint outpt(utxo.tx->GetHash(), utxo.i);
+        pwalletMain->LockCoin(outpt);
+    }
+    for (auto note : spendable.sproutNoteEntries) {
+        pwalletMain->LockNote(note.jsop);
+    }
+    for (auto note : spendable.saplingNoteEntries) {
+        pwalletMain->LockNote(note.op);
+    }
+}
+
+// TODO: Unlock Orchard notes
+void TransactionEffects::UnlockSpendable() const
+{
+    LOCK2(cs_main, pwalletMain->cs_wallet);
+    for (auto utxo : spendable.utxos) {
+        COutPoint outpt(utxo.tx->GetHash(), utxo.i);
+        pwalletMain->UnlockCoin(outpt);
+    }
+    for (auto note : spendable.sproutNoteEntries) {
+        pwalletMain->UnlockNote(note.jsop);
+    }
+    for (auto note : spendable.saplingNoteEntries) {
+        pwalletMain->UnlockNote(note.op);
+    }
 }

--- a/src/wallet/wallet_tx_builder.h
+++ b/src/wallet/wallet_tx_builder.h
@@ -49,7 +49,9 @@ public:
             CAmount amount,
             std::optional<Memo> memo,
             bool isInternal = false) :
-        address(address), amount(amount), memo(memo), isInternal(isInternal) {}
+        address(address), amount(amount), memo(memo), isInternal(isInternal) {
+        assert(amount >= 0);
+    }
 
     const PaymentAddress& GetAddress() const {
         return address;
@@ -189,6 +191,10 @@ public:
     const SpendableInputs& GetSpendable() const {
         return spendable;
     }
+
+    void LockSpendable() const;
+
+    void UnlockSpendable() const;
 
     const Payments& GetPayments() const {
         return payments;


### PR DESCRIPTION
This fixes an RPC test failure that tests specifically for this with z_shieldcoinbase. This also exposed an issue where an overly-high fee resulted in a negative Payment causing an exception too deep. Added an assert when creating a Payment and guarded against it for z_shieldcoinbase.

Fixes #2621 and #5654 (but does not handle Orchard locking, which is tracked in a separate issue).